### PR TITLE
Fix #15: minimal README pointing to the docs on hackage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+Some documentation is available at: https://hackage.haskell.org/package/zinza/docs/Zinza.html

--- a/zinza.cabal
+++ b/zinza.cabal
@@ -16,6 +16,7 @@ homepage:           https://github.com/phadej/zinza
 bug-reports:        https://github.com/phadej/zinza/issues
 tested-with:        GHC ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1
 extra-source-files:
+  README.md
   Changelog.md
   fixtures/*.zinza
   fixtures/*.hs


### PR DESCRIPTION
Fix #15: minimal README pointing to the docs on hackage